### PR TITLE
Handle multiple matches

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -80,23 +80,26 @@ function getServers() {
  * @return Object
  */
 function getBackend(request) {
-    var routes = getRoutes();
+    var matches = [],
+        routes = getRoutes();
+
     for (var i = 0; i < routes.length; i++) {
         var route = routes[i];
         if (!route.match.test(request.url)) {
             continue;
         }
         var servers = getServers();
-        for (i = 0; i < servers.length; i++) {
-            if (servers[i].id === route.id) {
-                return {
-                    serverURL: servers[i].url,
+        for (var j = 0; j < servers.length; j++) {
+            if (servers[j].id === route.id) {
+                matches.push({
+                    serverURL: servers[j].url,
                     savePath: urlToPath(request.url.replace(route.match, route.savePath))
-                };
+                });
             }
         }
     }
-    return null;
+
+    return (matches.length === 0 ? null : {matches: matches});
 }
 
 /**

--- a/chrome/devtools.js
+++ b/chrome/devtools.js
@@ -80,6 +80,7 @@ chrome.devtools.inspectedWindow.onResourceContentCommitted.addListener(function(
 
             function sendToBackgroundPage() {
                 var patch;
+
                 if (isNewlyAdded(event)) {
                     console.info('New CSS rules added. Appending them to', lastStylesheetURL);
                     var oldAddedCSS = addedCSS;
@@ -99,17 +100,25 @@ chrome.devtools.inspectedWindow.onResourceContentCommitted.addListener(function(
                     return;
                 }
 
-                chrome.extension.sendRequest({
-                    method: 'send',
-                    content: JSON.stringify(patch),
-                    url: response.serverURL,
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-URL': url,
-                        'X-Path': response.savePath,
-                        'X-Type': event.type
-                    }
-                });
+                if(!response.matches) {
+                    response.matches = [];
+                    response.matches.push(response);
+                }
+
+                for (var i=0; i<response.matches.length; i++) {
+                    var match = response.matches[i];
+                    chrome.extension.sendRequest({
+                        method: 'send',
+                        content: JSON.stringify(patch),
+                        url: match.serverURL,
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-URL': url,
+                            'X-Path': match.savePath,
+                            'X-Type': event.type
+                        }
+                    });
+                }
             }
         });
     }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,12 +1,14 @@
 {
     "name": "DevTools Autosave",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "Saves changes in CSS and JS that was made via Chrome DevTools",
 
     "devtools_page": "devtools.html",
+
     "background": {
         "scripts": ["background.js"]
     },
+
     "options_page": "options.html",
 
     "icons": {


### PR DESCRIPTION
Previously, the autosave extension would only send a diff message to the
first successful match it encountered. With this change, it will send to
all successful matches. This allows sending the same change to multiple
servers or "Save To" locations.
